### PR TITLE
Temporary change to allow users to force a target device in OVMS

### DIFF
--- a/model-mesh-ovms-adapter/server/config.go
+++ b/model-mesh-ovms-adapter/server/config.go
@@ -59,6 +59,10 @@ const (
 	defaultBatchWaitTimeMax        = 3 * time.Second
 	reloadTimeout           string = "OVMS_RELOAD_TIMEOUT"
 	defaultReloadTimeout           = 30 * time.Second
+
+	// (Xaenalt): Temporary workaround until OVMS can auto-detect Nvidia GPUs
+	ovmsForceTargetDevice        string = "OVMS_FORCE_TARGET_DEVICE"
+	defaultOvmsForceTargetDevice        = "CPU"
 )
 
 func GetAdapterConfigurationFromEnv(log logr.Logger) (*AdapterConfiguration, error) {
@@ -94,5 +98,9 @@ func GetAdapterConfigurationFromEnv(log logr.Logger) (*AdapterConfiguration, err
 	if adapterConfig.ModelSizeMultiplier <= 0 {
 		return nil, fmt.Errorf("%s environment variable must be greater than 0, found value %v", modelSizeMultiplier, adapterConfig.ModelSizeMultiplier)
 	}
+
+	// (Xaenalt): Temporary workaround until OVMS can auto-detect Nvidia GPUs
+	adapterConfig.OvmsForceTargetDevice = GetEnvString(ovmsForceTargetDevice, defaultOvmsForceTargetDevice)
+
 	return adapterConfig, nil
 }

--- a/model-mesh-ovms-adapter/server/modelconfig.go
+++ b/model-mesh-ovms-adapter/server/modelconfig.go
@@ -40,8 +40,9 @@ type OvmsMultiModelRepositoryConfig struct {
 }
 
 type OvmsMultiModelModelConfig struct {
-	Name     string `json:"name"`
-	BasePath string `json:"base_path"`
+	Name         string `json:"name"`
+	BasePath     string `json:"base_path"`
+	TargetDevice string `json:"target_device"`
 }
 
 type OvmsMultiModelConfigListEntry struct {

--- a/model-mesh-ovms-adapter/server/modelmanager.go
+++ b/model-mesh-ovms-adapter/server/modelmanager.go
@@ -434,11 +434,24 @@ func (mm *OvmsModelManager) gatherLoadRequests() map[string]*request {
 					stopChan = time.NewTimer(mm.config.BatchWaitTimeMin).C
 				}
 
+				// (Xaenalt): Temporary workaround until OVMS's auto plugin can handle NVIDIA devices
+				adapterConfig, err := GetAdapterConfigurationFromEnv(mm.log)
+
+				var ovmsTargetDevice string
+
+				if err != nil {
+					mm.log.Error(err, "Could not get Adapter Configuration, defaulting to CPU inferencing")
+					ovmsTargetDevice = "CPU"
+				} else {
+					ovmsTargetDevice = adapterConfig.OvmsForceTargetDevice
+				}
+
 				requestMap[req.modelId] = req
 				mm.loadedModelsMap[req.modelId] = OvmsMultiModelConfigListEntry{
 					Config: OvmsMultiModelModelConfig{
-						Name:     req.modelId,
-						BasePath: req.basePath,
+						Name:         req.modelId,
+						BasePath:     req.basePath,
+						TargetDevice: ovmsTargetDevice,
 					},
 				}
 			}

--- a/model-mesh-ovms-adapter/server/server.go
+++ b/model-mesh-ovms-adapter/server/server.go
@@ -48,6 +48,9 @@ type AdapterConfiguration struct {
 	BatchWaitTimeMin time.Duration
 	BatchWaitTimeMax time.Duration
 	ReloadTimeout    time.Duration
+
+	// (Xaenalt): Temporary workaround until OVMS can auto-detect Nvidia GPUs
+	OvmsForceTargetDevice string
 }
 
 type OvmsAdapterServer struct {


### PR DESCRIPTION
This is a workaround to the adapter that allows a user to set OVMS_FORCE_TARGET_DEVICE in the builtInAdapter.env section. This is then written into the config for each model that the model server manages

This is needed right now because when on a node with an Nvidia GPU, OVMS does not always ensure that the model goes onto the right device. 

The changes needed to the runtime are:

```
spec:
  builtInAdapter:
    env:
      - name: OVMS_FORCE_TARGET_DEVICE
        value: NVIDIA
```

Note, this actually accepts any value from https://github.com/openvinotoolkit/model_server/blob/main/docs/accelerators.md so it enables a lot of the interesting behavior OVMS is capable of