### PR TITLE
RHOAIENG-19620: [rhoai-2.8] Bump Go to 1.23.6 (#101)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,8 @@
 ###############################################################################
 # Stage 1: Create the developer image for the BUILDPLATFORM only
 ###############################################################################
-ARG GOLANG_VERSION=1.21
-FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi8/go-toolset:$GOLANG_VERSION AS develop
+ARG GOLANG_VERSION=1.23
+FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/go-toolset:$GOLANG_VERSION AS develop
 
 ARG PROTOC_VERSION=21.5
 

--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -1,8 +1,8 @@
 
 #ARG BUILD_BASE=develop
 
-#go-1.21
-FROM registry.redhat.io/ubi8/go-toolset:1.21@sha256:742ae6ec1aef3e7faae488c47695fb64964d342aefecf52d23bd9d5e6731d0b6 AS build
+#go-1.23
+FROM registry.redhat.io/ubi9/go-toolset:1.23@sha256:8a634d63713a073d7a1e086a322e57b148eef9620834fc8266df63d9294dff1b AS build
 
 USER root
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kserve/modelmesh-runtime-adapter
 
-go 1.21
+go 1.23.6
 
 require (
 	cloud.google.com/go/storage v1.28.1


### PR DESCRIPTION
Fix `CVE-2025-22866`.

CP of https://github.com/opendatahub-io/modelmesh-runtime-adapter/pull/102