### PR TITLE
Add missing requirements to 2.19

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ Once the final container is built, you can access it:
 ```bash
 podman run <modelmesh-runtime-adapter-container-name> sh -c 'pip freeze'
 ```
+`pip freeze` might omit some pachages, using `pip list` and formatting the `requirements.txt` has a more accurate result.
 
 Note, for `tensorflow-io-gcs-filesystem` it must be pinned to **0.34.0** manually after generating the `requirements.txt` file.`
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,10 +23,12 @@ numpy==2.1.3
 opt_einsum==3.4.0
 optree==0.16.0
 packaging==25.0
+pip==23.3
 protobuf==5.29.5
 Pygments==2.19.1
 requests==2.32.4
 rich==14.0.0
+setuptools==78.1.1
 six==1.17.0
 tensorboard==2.19.0
 tensorboard-data-server==0.7.2
@@ -37,4 +39,5 @@ termcolor==3.1.0
 typing_extensions==4.14.0
 urllib3==2.4.0
 Werkzeug==3.1.3
+wheel==0.45.1
 wrapt==1.17.2


### PR DESCRIPTION
#### Motivation
Update the requirements.txt as it was missing packages from last update. Cherry pick of https://github.com/red-hat-data-services/modelmesh-runtime-adapter/commit/2ff6ab36906aef20e9194131f0d68cbb489f5ed1

#### Modifications

#### Result
