### PR TITLE
fix: resolve GLIBC compatibility issue in ovms-adapter by using consistent UBI8 base images RHOAIENG-28912

### DIFF
--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -2,7 +2,7 @@
 #ARG BUILD_BASE=develop
 
 #go-1.23
-FROM registry.redhat.io/ubi9/go-toolset:1.23@sha256:381fb72f087a07432520fa93364f66b5981557f1dd708f3c4692d6d0a76299b3 AS build
+FROM registry.redhat.io/ubi8/go-toolset:1.23@sha256:1c14d28e0d5c7e6ec93dfe98b1e476ad7e000aa9d110ac955b31046359db7380 AS build
 
 #FROM --platform=$BUILDPLATFORM $BUILD_BASE AS build
 


### PR DESCRIPTION
The build stage was based on UBI9 (RHEL 9), which includes newer versions of the GLIBC library—specifically 2.32 and 2.34. As a result, the Go binary was compiled and linked against those newer versions. However, the runtime stage used UBI8 (RHEL 8), which only provides an older version of GLIBC (2.28). This created a mismatch: the binary expected to find the newer GLIBC versions at runtime, but they weren’t available in the UBI8 environment. Because of this version gap, the binary failed to start—it simply couldn’t find the GLIBC versions it had been built to rely on.



Problem:
- ovms-adapter was failing with GLIBC version errors:
  "/opt/app/ovms-adapter: /lib64/libc.so.6: version 'GLIBC_2.32' not found"
  "/opt/app/ovms-adapter: /lib64/libc.so.6: version 'GLIBC_2.34' not found"
- This caused the model mesh container to fail startup with timeout errors

Root Cause:
- Build stage used UBI9 (RHEL 9) with GLIBC 2.32/2.34
- Runtime stage used UBI8 (RHEL 8) with GLIBC 2.28  
- Go binary linked against newer GLIBC versions during build but older versions available at runtime
