### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for odh-modelmesh-runtime-adapter-v2-19

### DIFF
--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -89,7 +89,8 @@ ARG IMAGE_VERSION
 ARG COMMIT_SHA
 
 LABEL com.redhat.component="odh-modelmesh-runtime-adapter-container" \
-      name="managed-open-data-hub/odh-modelmesh-runtime-adapter-container-rhel8" \
+      name="rhoai/odh-modelmesh-runtime-adapter-rhel8" \
+      cpe="cpe:/a:redhat:openshift_ai:2.19::el8" \
       description="Container which runs in each model serving pod and act as an intermediary between model-mesh and third-party model-server containers" \
       summary="odh-model-serving-runtime-adapter" \
       maintainer="['managed-open-data-hub@redhat.com']" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
