### PR TITLE
[CVE-2026-1462]-chore: bump keras to 3.14.0 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,8 @@ grpcio==1.73.0
 # for arm yet.
 h5py==3.12.0
 idna==3.10
-keras==3.13.2
+# CVE-2026-1462 (Keras TFSMLayer bypasses safe_mode): addressed in keras 3.13.2+; use current stable.
+keras==3.14.0
 libclang==18.1.1
 Markdown==3.8.1
 markdown-it-py==3.0.0


### PR DESCRIPTION
## Summary
- Update Konflux prefetch `requirements.txt` to use `keras==3.14.0` (patched for CVE-2026-1462 / TFSMLayer safe_mode bypass).

## Rationale
CVE-2026-1462 describes arbitrary code execution when deserializing `.keras` models containing attacker-controlled SavedModels via `TFSMLayer`, bypassing `safe_mode=True`. Upstream fix disallows `TFSMLayer` deserialization in safe mode unless explicitly opting out (see upstream fix commit `b6773d3`).

## Test plan
- [x] `make test`

## References
- CVE: `https://www.cve.org/CVERecord?id=CVE-2026-1462`
- Upstream fix: `https://github.com/keras-team/keras/commit/b6773d3decaef1b05d8e794458e148cb362f163f`
- Huntr report: `https://huntr.com/bounties/7e78d6f1-6977-4300-b595-e81bdbda331c`

_Updated via RHOAI-CVE handler workflow system_