### PR TITLE
[RHOAIENG-59269] CVE-2026-23490: Pin pyasn1 to 0.6.2 (RELATIVE-OID DoS)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,6 +24,9 @@ opt_einsum==3.4.0
 optree==0.16.0
 packaging==25.0
 protobuf==5.29.5
+# CVE-2026-23490: pyasn1 denial of service via malformed RELATIVE-OID; fixed in 0.6.2.
+# Pinning because it is a transitive dependency.
+pyasn1==0.6.2
 Pygments==2.19.1
 requests==2.32.4
 rich==14.0.0


### PR DESCRIPTION
## Summary

Pins **pyasn1** to **0.6.2** in `requirements.txt` to address **CVE-2026-23490** (memory exhaustion / DoS from malformed RELATIVE-OID), fixed upstream in pyasn1 v0.6.2.

## Impact

The runtime image installs Python dependencies from `requirements.txt`. Adding an explicit version guarantees the container resolves the patched library regardless of transitive dependency choices.

## References

- https://www.cve.org/CVERecord?id=CVE-2026-23490  
- https://github.com/pyasn1/pyasn1/security/advisories/GHSA-63vm-454h-vhhq  