### PR TITLE
[RHOAIENG-63999] - Path traversal via pip wheel

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -172,6 +172,9 @@ ENV PIP_CACHE_DIR=/root/.cache/pip
 RUN --mount=type=cache,target=/root/.cache/pip \
     pip install -r requirements.txt
 RUN rm -rfv requirements.txt
+
+# CVE-2026-8643: Remove pip and build-time-only packages from the final image
+RUN microdnf remove -y python3.11-pip gcc gcc-c++ python3.11-devel && microdnf clean all
 USER ${USER}
 
 # Add modelmesh version

--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -65,6 +65,9 @@ ENV PIP_CACHE_DIR=/root/.cache/pip
 RUN --mount=type=cache,target=/root/.cache/pip \
     /usr/bin/pip3.11 install -r requirements.txt
 RUN rm -rfv requirements.txt
+
+# CVE-2026-8643: Remove pip and build-time-only packages from the final image
+RUN microdnf remove -y python3.11-pip gcc gcc-c++ python3.11-devel && microdnf clean all
 USER ${USER}
 
 # Add modelmesh version


### PR DESCRIPTION
chore: CVE-2026-8643 rhoai/odh-modelmesh-runtime-adapter-rhel9: Path traversal via malicious entry point name in pip wheel installation allows arbitrary file overwrite

#### Motivation

#### Modifications

#### Result
