### PR TITLE
[RHOAIENG-63852] CVE-2026-44432: urllib3 DoS due to excessive HTTP re…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -37,7 +37,8 @@ tensorflow==2.19.0
 tensorflow-io-gcs-filesystem==0.34.0
 termcolor==3.1.0
 typing_extensions==4.14.0
-urllib3==2.6.3
+# CVE-2026-44432: Denial of Service due to excessive HTTP response decompression fixed in urllib3 2.7.0
+urllib3==2.7.0
 Werkzeug==3.1.3
 wheel==0.46.2
 wrapt==1.17.2


### PR DESCRIPTION
…sponse decompression

chore: Bump urllib3 from 2.6.3 to 2.7.0 to fix CVE-2026-44432 denial of service vulnerability in HTTP response decompression streaming API.

#### Motivation

#### Modifications

#### Result
